### PR TITLE
(Important) Adjust max speed of test command

### DIFF
--- a/2023-IAP-Swerve/src/main/java/frc/robot/RobotContainer.java
+++ b/2023-IAP-Swerve/src/main/java/frc/robot/RobotContainer.java
@@ -36,7 +36,7 @@ public class RobotContainer {
 
   // Confirmed ready for testing 12/9
   // Switches to single module testing mode
-  private final boolean testSingleModule = false;
+  private final boolean testSingleModule = true;
   private final int testModuleIndex = 0;
   private final boolean testPIDF = false;
 

--- a/2023-IAP-Swerve/src/main/java/frc/robot/commands/TestSwerveModulePIDF.java
+++ b/2023-IAP-Swerve/src/main/java/frc/robot/commands/TestSwerveModulePIDF.java
@@ -8,6 +8,7 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants;
 import frc.robot.subsystems.swerve.SingularModule;
 
 public class TestSwerveModulePIDF extends CommandBase {
@@ -58,9 +59,9 @@ public class TestSwerveModulePIDF extends CommandBase {
       velocity = 3.0;
     }
 
-    // Driving to 4.0 - Right trigger bumper (lower)
+    // Driving to 3.7 - Right trigger bumper (lower)
     if (joy.getRawButton(7)) {
-      velocity = 4.0;
+      velocity = Constants.ModuleConstants.maxFreeWheelSpeedMeters;
     }
 
     // Driving to pi/4 - Button X

--- a/2023-IAP-Swerve/src/main/java/frc/robot/subsystems/swerve/SwerveModuleIOSparkMax.java
+++ b/2023-IAP-Swerve/src/main/java/frc/robot/subsystems/swerve/SwerveModuleIOSparkMax.java
@@ -6,6 +6,7 @@ package frc.robot.subsystems.swerve;
 
 import com.ctre.phoenix.sensors.AbsoluteSensorRange;
 import com.ctre.phoenix.sensors.CANCoder;
+import com.ctre.phoenix.sensors.SensorInitializationStrategy;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.SparkMaxPIDController;
@@ -63,6 +64,7 @@ public class SwerveModuleIOSparkMax implements SwerveModuleIO {
     public SwerveModuleIOSparkMax(int num, int driveID, int turnID, int turnCANCoderID, double turnEncoderOffset) {
 
         turnEncoder = new CANCoder(turnCANCoderID);
+        turnEncoder.configFactoryDefault();
 
         // Construct CANSparkMaxes
         driveSparkMax = new CANSparkMax(driveID, MotorType.kBrushless);
@@ -106,15 +108,17 @@ public class SwerveModuleIOSparkMax implements SwerveModuleIO {
 
         // Set position of encoder to absolute mode
         turnEncoder.setPositionToAbsolute();
-        turnEncoder.configAbsoluteSensorRange(AbsoluteSensorRange.Signed_PlusMinus180);
+        turnEncoder.configSensorInitializationStrategy(SensorInitializationStrategy.BootToAbsolutePosition);
+        turnEncoder.configAbsoluteSensorRange(AbsoluteSensorRange.Unsigned_0_to_360);
         turnEncoder.configMagnetOffset(turnEncoderOffset);
 
         turnPID.setP(Constants.ModuleConstants.drivekP);
         turnPID.setI(Constants.ModuleConstants.drivekI);
         turnPID.setD(Constants.ModuleConstants.drivekD);
 
-        // Continous input jumping from -PI to PI
-        turnPID.enableContinuousInput(-Math.PI, Math.PI);
+        // Continous input jumping from 0 to 2*PI
+        // Not advisable for Derivative constant
+        turnPID.enableContinuousInput(0, 2*Math.PI);
 
         this.state.angle = new Rotation2d(getTurnPositionInRad());
 


### PR DESCRIPTION
Adjusts max speed of test command to max free speed of the wheel. This might sound dangerous, as the motor should be spinning at ~5000 RPM, but this max speed is expected. Also fixes wrapping on PID of turning motor.